### PR TITLE
chore: '@typescript-eslint/prefer-reduce-type-parameter'

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -90,7 +90,6 @@ const config = [
       '@typescript-eslint/restrict-plus-operands': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
-      '@typescript-eslint/prefer-reduce-type-parameter': 'off',
       '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/prefer-regexp-exec': 'off',

--- a/src/photo/StaggeredOgPhotos.tsx
+++ b/src/photo/StaggeredOgPhotos.tsx
@@ -17,14 +17,8 @@ export default function StaggeredOgPhotos({
   maxConcurrency?: number;
   onLastPhotoVisible?: () => void;
 }) {
-  const [loadingState, setLoadingState] = useState(
-    photos.reduce(
-      (accumulator, photo) => ({
-        ...accumulator,
-        [photo.id]: 'unloaded' as const,
-      }),
-      {} as PhotoLoadingState,
-    ),
+  const [loadingState, setLoadingState] = useState<PhotoLoadingState>(
+    Object.fromEntries(photos.map(photo => [photo.id, 'unloaded' as const])),
   );
 
   const recomputeLoadingState = useCallback(

--- a/src/video/StaggeredOgVideos.tsx
+++ b/src/video/StaggeredOgVideos.tsx
@@ -17,14 +17,8 @@ export default function StaggeredOgVideos({
   maxConcurrency?: number;
   onLastVideoVisible?: () => void;
 }) {
-  const [loadingState, setLoadingState] = useState(
-    videos.reduce(
-      (accumulator, video) => ({
-        ...accumulator,
-        [video.id]: 'unloaded' as const,
-      }),
-      {} as VideoLoadingState,
-    ),
+  const [loadingState, setLoadingState] = useState<VideoLoadingState>(
+    Object.fromEntries(videos.map(video => [video.id, 'unloaded' as const])),
   );
 
   const recomputeLoadingState = useCallback(


### PR DESCRIPTION
The fix for this error eslint style (passing the type as an arg), summons the unicorn linter : Prefer `Object.fromEntries()` over `Array#reduce()`.
