### PR TITLE
chore: @typescript-eslint/no-unnecessary-boolean-literal-compare

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,7 +86,6 @@ const config = [
       'unicorn/prefer-add-event-listener': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',
       '@typescript-eslint/no-confusing-void-expression': 'off',
-      '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
       '@typescript-eslint/restrict-plus-operands': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -56,7 +56,7 @@ export default function PhotoGrid({
             : 'grid-cols-2 sm:grid-cols-4 md:grid-cols-3 lg:grid-cols-4',
         'items-center',
       )}
-      type={animate === false ? 'none' : undefined}
+      type={animate ? undefined : 'none'}
       canStart={canStart}
       duration={fast ? 0.3 : undefined}
       staggerDelay={0.075}

--- a/src/video/VideoGrid.tsx
+++ b/src/video/VideoGrid.tsx
@@ -54,7 +54,7 @@ export default function VideoGrid({
             : 'grid-cols-2 sm:grid-cols-4 md:grid-cols-3 lg:grid-cols-4',
         'items-center',
       )}
-      type={animate === false ? 'none' : undefined}
+      type={animate ? undefined : 'none'}
       canStart={canStart}
       duration={fast ? 0.3 : undefined}
       staggerDelay={0.075}


### PR DESCRIPTION
forgot my ternary operator logic for a second, but this should work the same